### PR TITLE
Failing tests for contentType

### DIFF
--- a/test/contentType.coffee
+++ b/test/contentType.coffee
@@ -78,3 +78,50 @@ test "Fauxjax can handle text/json content type", (assert) ->
       assert.ok(false, "Faux request does match real request data. Request should not have returned and error")
     complete: (xhr, textStatus) ->
       done()
+
+test "Fauxjax returns the proper error response content and content type", (assert) ->
+  done = assert.async()
+  $.fauxjax.new
+    method: 'POST'
+    url: '/faux-request'
+    data: {'email': 'invalidemail'}
+    status: 400
+    responseText: {'email': ['Bad value']}
+    contentType: 'application/json'
+
+  $.ajax
+    method: 'POST'
+    url: '/faux-request'
+    data: {'email': 'invalidemail'}
+    success: ->
+      assert.ok(false, "Fauxjax did not return an error when it should have.")
+    error: (xhr) ->
+      assert.ok(
+        _.isEqual(xhr.responseJSON, {'email': ['Bad value']}),
+        "Fauxjax did not return the correct response data")
+    complete: ->
+      done()
+
+test "Fauxjax returns the proper success response content and content type", (assert) ->
+  done = assert.async()
+  $.fauxjax.new
+    method: 'POST'
+    url: '/faux-request'
+    data: {'email': 'valid@email.com'}
+    status: 200
+    responseText: {'status': 'good'}
+    contentType: 'application/json'
+
+  $.ajax
+    method: 'POST'
+    url: '/faux-request'
+    data: {'email': 'valid@email.com'}
+    success: (data) ->
+      assert.ok(
+        _.isEqual(data, {'status': 'good'}),
+        "Fauxjax did not return the correct response data")
+      assert.ok(true, "Fauxjax did not return a success response when it should have.")
+    error: (xhr) ->
+      assert.ok(false, "Fauxjax returned an error when it should not have.")
+    complete: ->
+      done()


### PR DESCRIPTION
My tests kind of suck here—it's late and I'm seeing double.

At any rate, this is an attempt to show the trouble I'm having with contentType.  In my project code, I can make this work by removing `contentType: 'application/json'` from `new`, and adding `$.fauxjax.settings.contentType = 'application/json';` before it.  I wasn't able to simulate the success with the settings in the test here—for some reason the test runner was throwing a Promise error whenever I tried which seemed to be unrelated to what I am attempting to show.
