### PR TITLE
Failing test for JSON response on error

### DIFF
--- a/test/requestStatus.coffee
+++ b/test/requestStatus.coffee
@@ -61,3 +61,26 @@ test "Fauxjax with status of 200 returns a success and status is 200", (assert) 
     complete: (xhr, textStatus) ->
       assert.equal(xhr.status, 200, "Fauxjax was created as a success of 200 but actually returned: #{xhr.status}")
       done()
+
+test "Fauxjax can return JSON data with an error", (assert) ->
+  done = assert.async()
+  $.fauxjax.new
+    method: 'POST'
+    url: '/faux-request'
+    data: {'username': ''}
+    status: 400
+    responseText: {'username': ['This field is required']}
+
+  $.ajax
+    method: 'POST'
+    url: '/faux-request'
+    data: {'username': ''}
+    success: ->
+      assert.ok(false, "Returned a success response when it should have been an error")
+    error: (xhr) ->
+      assert.ok(_.isEqual(xhr.responseJSON, {'username': ['This field is required']}),
+        "Expected JSON data in response to contain field error, but got: #{xhr.responseJSON}")
+    complete: ->
+      done()
+
+  return true


### PR DESCRIPTION
There should be a way to specify the Content-Type of the response so that calls to `$.ajax` do not have to explicitly declare `dataType`

From the jQuery docs:

> The type of pre-processing depends by default upon the Content-Type of the response, but can be set explicitly using the dataType option. If the dataType option is provided, the Content-Type header of the response will be disregarded.

Fauxjax provides the `dataType` settings, but this seems to be used for matching the request from the `$.ajax` call, not for preparing the actual response.  There should be a way to adjust the response data type in a way that does not affect request matching.
