### PR TITLE
Enhancement: Add support for application/vnd.api+json (JSON API) content type to match application/json support

### DIFF
--- a/src/fauxjax.js
+++ b/src/fauxjax.js
@@ -130,7 +130,7 @@
      * @returns {String} Returns the contentType
      */
     function parseContentType(handler) {
-      if (_.startsWith(handler.contentType, 'application/json')) { return 'application/json'; }
+      if (_.includes(handler.contentType, 'json')) { return 'application/json'; }
       return 'application/x-www-form-urlencoded';
     }
 
@@ -144,7 +144,7 @@
      * @returns {String|Object}    The parsed data to be compared for a match
      */
     function parseData(data, contentType) {
-      if (_.isEqual(contentType, 'application/json') && !_.isObject(data)) { return JSON.parse(data); }
+      if (_.includes(['application/vnd.api+json', 'application/json'], contentType) && !_.isObject(data)) { return JSON.parse(data); }
       return data;
     }
 

--- a/test/dataContents.coffee
+++ b/test/dataContents.coffee
@@ -146,6 +146,29 @@ test "When faux and real request have the same data both JSON.stringify'd object
     complete: (xhr, textStatus) ->
       done()
 
+test "When faux and real request have the same data both JSON.stringify'd objects the request is successfully faked for application/vnd.api+json", (assert) ->
+  done = assert.async()
+  $.fauxjax.new
+    request:
+      method: "POST"
+      url: "/faux-request"
+      contentType: "application/vnd.api+json"
+      data: JSON.stringify({foo: "bar", wat: "baz"})
+    response:
+      content: {fakeResponse: "Post success"}
+
+  $.ajax
+    method: "POST"
+    url: "/faux-request"
+    data: JSON.stringify({wat: "baz", foo: "bar"})
+    contentType: "application/vnd.api+json"
+    success: (data, textStatus, xhr) ->
+      assert.ok(_.isEqual(data, {"fakeResponse": "Post success"}), "Response text not a match received: #{data}")
+    error: (xhr, textStatus) ->
+      assert.ok(false, "Faux data does match the real request data. The request should not have returned an error")
+    complete: (xhr, textStatus) ->
+      done()
+
 test "Correctly matches request data when empty objects", (assert) ->
   done = assert.async()
   expect(0)


### PR DESCRIPTION
Currently the parsing of json strings (#19) into objects is only supported for `application/json`. JSON API uses a content type of `application/vnd.api+json` (Why, I wish I knew). When testing with fauxjax this became unmaintainable because all of our request data had to be strings which are tedious to change. 

This PR just adds `application/vnd.api+json` as an acceptable content type to parse a string into an object. Basically making it behave exactly like `application/json` does currently.